### PR TITLE
Add ExtraParams

### DIFF
--- a/maintainerr/maintainerr.xml
+++ b/maintainerr/maintainerr.xml
@@ -14,7 +14,7 @@
   <WebUI>http://[IP]:[PORT:6246]</WebUI>
   <TemplateURL/>
   <Icon>https://github.com/jorenn92/Maintainerr/blob/main/ui/public/logo.png?raw=true</Icon>
-  <ExtraParams/>
+  <ExtraParams>-u 99:100</ExtraParams>
   <PostArgs/>
   <CPUset/>
   <DateInstalled>1694018747</DateInstalled>


### PR DESCRIPTION
Add ExtraParams `-u 99:100` so it uses the `nobody` user when trying to write to the data config folder.

This will fix the `THE CONTAINER NO LONGER OPERATES WITH PRIVILEGED USER PERMISSIONS. PLEASE UPDATE YOUR CONFIGURATION ACCORDINGLY`error that occrus on first time setup if you havent set the correct permissions on the folder beforehand. 